### PR TITLE
Update installation guide with vcpkg package data note

### DIFF
--- a/src/zh/guide/install/install_zlmediakit_using_vcpkg.md
+++ b/src/zh/guide/install/install_zlmediakit_using_vcpkg.md
@@ -8,6 +8,8 @@ vcpkg 是一个跨平台的 sdk 包管理工具，类似于 linux 下的 yum/apt
 目前 zlmediakit 已经于 2023-08-08 完成 vcpkg 平台的上线，用户可以通过 vcpkg 便捷安装 zlmediakit c sdk 以及 MediaServer 可执行程序，解决各种编译依赖相关的苦恼。
 zlmediakit 上架 vcpkg 得到了[@JackBoosY](https://github.com/JackBoosY)大量的支持，在此表示由衷的感谢！
 
+# 提示：此安装方式的包数据更新到 2024-09-29 稳定版，尝鲜或者使用最新发布版本请通过其他方式安装。
+
 # 安装指导
 
 ## 1、安装 vcpkg


### PR DESCRIPTION
Added a note about package data update for vcpkg installation. vcpkg的安装包最后更新日期为2024-09-29 在这里增加个提示，新版本需要用其他方式安装。 我一顿捣鼓，最后发现这个问题的。还要用其他方式来安装。在这里加个提醒，想用稳定版的可以继续，否则就老老实实其他方式安装吧。